### PR TITLE
It looks like the LendingProtocol contract was missing the implementa…

### DIFF
--- a/src/core/LendingProtocol.sol
+++ b/src/core/LendingProtocol.sol
@@ -681,4 +681,13 @@ contract LendingProtocol is
             totalRepayment
         );
     }
+
+    function onERC721Received(
+        address operator,
+        address from,
+        uint256 tokenId,
+        bytes calldata data
+    ) external override returns (bytes4) {
+        return this.onERC721Received.selector;
+    }
 }


### PR DESCRIPTION
…tion for the `onERC721Received` function. This is required by the `IERC721Receiver` interface it inherits, and was causing a compilation error indicating that LendingProtocol should be marked as abstract.

I've added the standard implementation of `onERC721Received`, which returns `this.onERC721Received.selector`. This should satisfy the interface requirement and resolve the compilation error for you.