### PR TITLE
I fixed `RoyaltyManagerTest` by mocking `IIPAssetRegistry`.

### DIFF
--- a/src/mocks/MockIIPAssetRegistry.sol
+++ b/src/mocks/MockIIPAssetRegistry.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {IIPAssetRegistry} from "@storyprotocol/contracts/interfaces/registries/IIPAssetRegistry.sol";
+
+contract MockIIPAssetRegistry is IIPAssetRegistry {
+    mapping(address => bool) private _isRegistered; // Renamed from public isRegistered
+    mapping(uint256 => mapping(address => mapping(uint256 => address))) public ipAssets;
+
+    // --- IIPAssetRegistry Functions ---
+
+    function register(uint256 chainId, address tokenContract, uint256 tokenId) external override returns (address ipId) {
+        ipId = computeIpId(chainId, tokenContract, tokenId);
+        _isRegistered[ipId] = true;
+        ipAssets[chainId][tokenContract][tokenId] = ipId;
+        // Emit IPRegistered event (optional for mock, but good practice)
+        emit IPRegistered(ipId, chainId, tokenContract, tokenId, "MockNFT", "", block.timestamp);
+        return ipId;
+    }
+
+    function ipId(uint256 chainId, address tokenContract, uint256 tokenId) external view override returns (address) {
+        return ipAssets[chainId][tokenContract][tokenId];
+    }
+
+    // Interface uses `id` as parameter name, ensuring consistency
+    function isRegistered(address id) external view override returns (bool) {
+        return _isRegistered[id];
+    }
+
+    function setRegistrationFee(address /*treasury*/, address /*feeToken*/, uint96 /*feeAmount*/) external override {
+        // Emit RegistrationFeeSet event (optional)
+    }
+
+    function totalSupply() external view override returns (uint256) {
+        return 0; // Mocked value
+    }
+
+    function upgradeIPAccountImpl(address /*newIpAccountImpl*/) external override {
+        // Mocked
+    }
+
+    function getTreasury() external view override returns (address) {
+        return address(0); // Mocked value
+    }
+
+    function getFeeToken() external view override returns (address) {
+        return address(0); // Mocked value
+    }
+
+    function getFeeAmount() external view override returns (uint96) {
+        return 0; // Mocked value
+    }
+
+    // --- IIPAccountRegistry Functions (inherited by IIPAssetRegistry) ---
+
+    function ipAccount(uint256 /*chainId*/, address /*tokenContract*/, uint256 /*tokenId*/) external view override returns (address) {
+        return address(0); // Mocked value, could be a mock IPAccount if needed
+    }
+
+    function getIPAccountImpl() external view override returns (address) {
+        return address(0); // Mocked value
+    }
+
+    // --- Helper Functions (not part of the interface, but used by this mock) ---
+
+    function computeIpId(uint256 chainId, address tokenContract, uint256 tokenId) public pure returns (address) {
+        return address(uint160(uint256(keccak256(abi.encodePacked(chainId, tokenContract, tokenId)))));
+    }
+
+    // --- Removed Functions Not in IIPAssetRegistry or IIPAccountRegistry ---
+    // EXPIRY_NEVER, POLICY_FRAMEWORK_MANAGER_HOOK_TAG, etc. (all TAG functions)
+    // attachLicenseTerms (both overloads)
+    // initialize
+    // owner
+    // pause, paused, unpause
+    // proxiableUUID
+    // register (overloaded version with string URI etc.)
+    // registerDerivative, registerDerivativeWithLicenseTokens
+    // setBaseURI, setBeneficiary, setRoyaltyPolicy, setTokenContract
+    // supportsInterface
+    // upgradeToAndCall
+    // metadata, beneficiaryOf, parentIpIdsOf, childIpIdsOf, royaltyPolicyOf
+    // tokenContractOf, tokenIdOf, chainIdOf, uri, exists
+}

--- a/test/RoyaltyManager.t.sol
+++ b/test/RoyaltyManager.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.26;
 import "forge-std/Test.sol";
 import "../src/core/RoyaltyManager.sol";
 import "../src/mocks/ERC721Mock.sol";
+import "../src/mocks/MockIIPAssetRegistry.sol"; // Added import
 import "@storyprotocol/contracts/interfaces/registries/IIPAssetRegistry.sol";
 import "@storyprotocol/contracts/interfaces/modules/royalty/IRoyaltyModule.sol";
 import "@storyprotocol/contracts/interfaces/modules/licensing/ILicensingModule.sol";
@@ -12,11 +13,12 @@ import "@storyprotocol/contracts/interfaces/registries/ILicenseRegistry.sol";
 contract RoyaltyManagerTest is Test {
     RoyaltyManager public royaltyManager;
     ERC721Mock public mockNft;
+    MockIIPAssetRegistry public mockIpAssetRegistry; // Added mock instance
     address public owner;
     address public user;
 
     // Story Protocol Mainnet Addresses
-    IIPAssetRegistry constant IP_ASSET_REGISTRY = IIPAssetRegistry(0x77319B4031e6eF1250907aa00018B8B1c67a244b);
+    // IIPAssetRegistry constant IP_ASSET_REGISTRY = IIPAssetRegistry(0x77319B4031e6eF1250907aa00018B8B1c67a244b); // Commented out or remove
     IRoyaltyModule constant ROYALTY_MODULE = IRoyaltyModule(0xD2f60c40fEbccf6311f8B47c4f2Ec6b040400086);
     ILicensingModule constant LICENSING_MODULE = ILicensingModule(0x04fbd8a2e56dd85CFD5500A4A4DfA955B9f1dE6f);
     ILicenseRegistry constant LICENSE_REGISTRY = ILicenseRegistry(0x529a750E02d8E2f15649c13D69a465286a780e24);
@@ -26,8 +28,10 @@ contract RoyaltyManagerTest is Test {
         user = address(0x1);
         vm.deal(user, 10 ether);
 
+        mockIpAssetRegistry = new MockIIPAssetRegistry(); // Instantiate mock
+
         royaltyManager = new RoyaltyManager(
-            address(IP_ASSET_REGISTRY),
+            address(mockIpAssetRegistry), // Use mock address
             address(ROYALTY_MODULE),
             address(LICENSING_MODULE),
             address(LICENSE_REGISTRY)
@@ -38,11 +42,11 @@ contract RoyaltyManagerTest is Test {
 
         // Register the NFT as an IP Asset on Story Protocol
         vm.prank(user);
-        IP_ASSET_REGISTRY.register(block.chainid, address(mockNft), 1);
+        mockIpAssetRegistry.register(block.chainid, address(mockNft), 1); // Use mock for registration
     }
 
     function testClaimRoyalty() public {
-        address ipId = IP_ASSET_REGISTRY.ipId(block.chainid, address(mockNft), 1);
+        address ipId = mockIpAssetRegistry.ipId(block.chainid, address(mockNft), 1); // Use mock for ipId retrieval
 
         // This test requires that the IP has parents with royalty policies.
         // For a unit test, you would mock these dependencies.


### PR DESCRIPTION
The `RoyaltyManagerTest.setUp()` function was failing because it attempted to interact with a hardcoded mainnet Story Protocol contract (`IIPAssetRegistry`) in a local test environment.

This commit introduces a mock contract `MockIIPAssetRegistry.sol` that implements the `IIPAssetRegistry` interface. `RoyaltyManagerTest.sol` has been updated to use this mock, allowing the tests to pass in a local environment.

All tests now pass.