### PR TITLE
Fix: Correct RoyaltyModule interface for stateful operations

### DIFF
--- a/src/RoyaltyModule.sol
+++ b/src/RoyaltyModule.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.26;
 
 contract RoyaltyModule {
     // Placeholder for royalty collection logic
-    function collectRoyaltyTokens(address, address) external pure returns (uint256) {
+    function collectRoyaltyTokens(address, address) external returns (uint256) {
         // This function will be implemented with the actual Story Protocol royalty collection logic
         return 0; // Placeholder return value
     }


### PR DESCRIPTION
The `RoyaltyModule.collectRoyaltyTokens` function was incorrectly declared as `pure`. This caused `StateChangeDuringStaticCall` errors when `RoyaltyManager` interacted with mock implementations of `RoyaltyModule` that performed state changes (e.g., `MockRoyaltyModule`).

This commit updates the `collectRoyaltyTokens` function signature in `src/RoyaltyModule.sol` from `external pure returns (uint256)` to `external returns (uint256)`, allowing implementing contracts to modify state as intended.

All tests now pass after this change.